### PR TITLE
Added email with txt/ascii only

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,16 +4,16 @@ var nodemailer = require('nodemailer');
 var mail_user, mail_pass, mail_host, mail_port, mail_from, mail_secure, use_credentials;
 
 function init() {
-	
+
 	//mail settings (if any)
 	use_credentials = Homey.manager('settings').get('use_credentials');
-	
+
 	//backwards compatibility
 	if (typeof use_credentials == undefined || typeof use_credentials == 'undefined') {
 		use_credentials = true;
 		Homey.manager('settings').set( 'use_credentials', true);
 	}
-	
+
 	mail_user = Homey.manager('settings').get('mail_user');
 	mail_pass = Homey.manager('settings').get('mail_password');
 	mail_host = Homey.manager('settings').get('mail_host');
@@ -32,14 +32,14 @@ Homey.manager('settings').on('set', function (name) {
 
 	Homey.log('variable ' + name + ' has been set');
 	init();
-	
+
 });
 
 // flow action handlers
 Homey.manager('flow').on('action.sendmail', function (callback, args) {
-	
+
 	if ( typeof mail_user !== 'undefined' && typeof mail_pass !== 'undefined' && typeof mail_host !== 'undefined' && typeof mail_port !== 'undefined' && typeof mail_from !== 'undefined') {
-	
+
 			if (typeof use_credentials == undefined) use_credentials = true;
 
 			if (use_credentials) {
@@ -52,7 +52,7 @@ Homey.manager('flow').on('action.sendmail', function (callback, args) {
 						user: mail_user,
 						pass: mail_pass
 					},
-					tls: {rejectUnauthorized: false} 
+					tls: {rejectUnauthorized: false}
 				});
 			} else {
 				// Don't use authentication. Not supported by all providers
@@ -61,19 +61,19 @@ Homey.manager('flow').on('action.sendmail', function (callback, args) {
 					host: mail_host,
 					port: mail_port,
 					secure: mail_secure,
-					tls: {rejectUnauthorized: false} 
+					tls: {rejectUnauthorized: false}
 				});
 			}
-		    
+
 		    var mailOptions = {
-				
+
 				from: 'Homey <' + mail_from + '>',
 			    to: args.mailto,
 			    subject: args.subject,
 			    text: args.body,
-				html: args.body
+				  html: args.body
 		    }
-		    
+
 		    transporter.sendMail(mailOptions, function(error, info){
 			    if(error){
 				    callback (error, false);
@@ -82,21 +82,22 @@ Homey.manager('flow').on('action.sendmail', function (callback, args) {
 			    Homey.log('Message sent: ' + info.response);
 			    callback (null, true);
 			});
-			
+
 		} else {
-			
+
 			Homey.log('Not all required variables for mailing have been set');
-		    
+
 			callback ('Not all required variables for mailing have been set', false);
-			
+
 		}
-	
+
 });
 
-Homey.manager('flow').on('action.sendimage', function (callback, args) {
-	
+
+Homey.manager('flow').on('action.sendascii', function (callback, args) {
+
 	if ( typeof mail_user !== 'undefined' && typeof mail_pass !== 'undefined' && typeof mail_host !== 'undefined' && typeof mail_port !== 'undefined' && typeof mail_from !== 'undefined') {
-	
+
 			if (typeof use_credentials == undefined) use_credentials = true;
 
 			if (use_credentials) {
@@ -109,7 +110,7 @@ Homey.manager('flow').on('action.sendimage', function (callback, args) {
 						user: mail_user,
 						pass: mail_pass
 					},
-					tls: {rejectUnauthorized: false} 
+					tls: {rejectUnauthorized: false}
 				});
 			} else {
 				// Don't use authentication. Not supported by all providers
@@ -118,16 +119,74 @@ Homey.manager('flow').on('action.sendimage', function (callback, args) {
 					host: mail_host,
 					port: mail_port,
 					secure: mail_secure,
-					tls: {rejectUnauthorized: false} 
+					tls: {rejectUnauthorized: false}
 				});
 			}
-			
+
+		    var mailOptions = {
+
+				from: 'Homey <' + mail_from + '>',
+			    to: args.mailto,
+			    subject: args.subject,
+			    text: args.body,
+				  //html: args.body
+		    }
+
+		    transporter.sendMail(mailOptions, function(error, info){
+			    if(error){
+				    callback (error, false);
+			        return Homey.log(error);
+			    }
+			    Homey.log('Message sent: ' + info.response);
+			    callback (null, true);
+			});
+
+		} else {
+
+			Homey.log('Not all required variables for mailing have been set');
+
+			callback ('Not all required variables for mailing have been set', false);
+
+		}
+
+});
+
+
+Homey.manager('flow').on('action.sendimage', function (callback, args) {
+
+	if ( typeof mail_user !== 'undefined' && typeof mail_pass !== 'undefined' && typeof mail_host !== 'undefined' && typeof mail_port !== 'undefined' && typeof mail_from !== 'undefined') {
+
+			if (typeof use_credentials == undefined) use_credentials = true;
+
+			if (use_credentials) {
+				var transporter = nodemailer.createTransport(
+				{
+					host: mail_host,
+					port: mail_port,
+					secure: mail_secure,
+					auth: {
+						user: mail_user,
+						pass: mail_pass
+					},
+					tls: {rejectUnauthorized: false}
+				});
+			} else {
+				// Don't use authentication. Not supported by all providers
+				var transporter = nodemailer.createTransport(
+				{
+					host: mail_host,
+					port: mail_port,
+					secure: mail_secure,
+					tls: {rejectUnauthorized: false}
+				});
+			}
+
 			//var body = '';
 			//body.append('photo', new Buffer(args.body, 'base64'),{contentType: 'image/jpeg', filename: 'x.jpg'})
-			
-		    
+
+
 		    var mailOptions = {
-				
+
 				from: 'Homey <' + mail_from + '>',
 			    to: args.mailto,
 			    subject: args.subject,
@@ -139,7 +198,7 @@ Homey.manager('flow').on('action.sendimage', function (callback, args) {
 				 encoding: 'base64'
 				}]
 		    }
-		    
+
 		    transporter.sendMail(mailOptions, function(error, info){
 			    if(error){
 				    callback (error, false);
@@ -148,13 +207,13 @@ Homey.manager('flow').on('action.sendimage', function (callback, args) {
 			    Homey.log('Message sent: ' + info.response);
 			    callback (null, true);
 			});
-			
+
 		} else {
-			
+
 			Homey.log('Not all required variables for mailing have been set');
-		    
+
 			callback ('Not all required variables for mailing have been set', false);
-			
+
 		}
-	
+
 });

--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
         "en": "Email sender",
         "nl": "Email versturen"
     },
-    "version": "0.1.5",
+    "version": "0.1.6",
     "compatibility": ">=0.8.29",
     "author": {
         "name": "Chamid Media",
@@ -64,6 +64,39 @@
 		              }
 	              }
 	        ]
+        },
+        {
+            "id": "sendascii",
+            "title": {
+                "en": "Send a txt mail",
+                "nl": "Stuur een txt e-mail"
+            },
+            "args": [
+                {
+                  "name": "mailto",
+                  "type": "text",
+                  "placeholder": {
+                    "en": "Mail to",
+                    "nl": "Mail aan"
+                  }
+                },
+                {
+                  "name": "subject",
+                  "type": "text",
+                  "placeholder": {
+                    "en": "Subject",
+                    "nl": "Onderwerp"
+                  }
+                },
+                {
+                  "name": "body",
+                  "type": "text",
+                  "placeholder": {
+                    "en": "Content",
+                    "nl": "Inhoud"
+                  }
+                }
+          ]
         },
         {
             "id": "sendimage",


### PR DESCRIPTION
Hi Jorden, 
For emailing my Logs from Homey I receive all txt lines separated with \n on one line in my email clients (tested several). 

To prevent all lines appended I need to send only the text body and skip sending  the html body. 
I created a extra action card to send txt/ascii only, but  reducing core and separating the callback from the only changed mailoptions that differ between the functions isn't fortunately something I could do. 

I duplicated the code but I guess you could do better ;-) 

Can you add this code or rewrite and publish a version of the app that has an option for only  text body? 

Thanks! Geurt